### PR TITLE
Add M option to download only media tweets

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Usage:
 -r, --retweet                Download retweet too
 -z, --url                    Print media url without download it
 -R, --retweet-only           Donwload only retweet
+-M, --mediatweet-only        Donwload only media tweet
 -s, --size     SIZE          Choose format between small|normal|large
                              (default large)
 -U, --update                 Download missing tweet only


### PR DESCRIPTION
Hello.
I use this a lot all the time.

The twitter-scraper has [GetMediaTweets](https://github.com/imperatrona/twitter-scraper?tab=readme-ov-file#get-user-medias). It seems to get only media tweets, so it can get more images with fewer requests than GetTweets.

Hope this helps you.

ex.
```bash
> .\twmd.exe -u elonmusk -n 10 -a -U -P -B
Logged in
Downloaded GZD-qc0W4AARcnY.jpg

> .\twmd.exe -u elonmusk -n 10 -a -U -P -B -M
Logged in
GZD-qc0W4AARcnY.jpg: already exists
Downloaded GY8vFGzbAAEBfDg.jpg
Downloaded GZAwoihbAAA-O0I.jpg
Downloaded GZAwSMCbAAEn6-a.jpg
Downloaded GZEj-UPXYAAPPO7.jpg
Downloaded GYtAU28XgAA7Df0.jpg
Downloaded GYyBoIEXcAIKOYN.jpg
Downloaded GYyfpL1XEAQUWUP.jpg
Downloaded GYr3FTIXkAAQUaR.jpg
Downloaded HT0kA6sVMsYteHyt.mp4
```

